### PR TITLE
[SWP-1932] Hotfix Changes. Allow passing of different options to findReview()

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,13 @@ $trustpilot = Reviews::trustpilot();
 Here is an example of the provided interface that is shared across the supported review providers.
 ```php
 $trustpilot->merchant()->invite((array) $serviceInviteOptions);
-$trustpilot->merchant()->findReview((string) $reviewId);
+$trustpilot->merchant()->findReview((array) $options);
 $trustpilot->merchant()->getReviews((array) $serviceReviewsFilterOptions);
 ```
 
 For more details about each provider request options see:
- * [Trustpilot](https://github.com/Pod-Point/reviews-php/blob/master/src/Providers/Trustpilot/README.md) 
- * [ReviewsIO](https://github.com/Pod-Point/reviews-php/blob/master/src/Providers/ReviewsIo/README.md) 
+ * [Trustpilot](https://github.com/Pod-Point/reviews-php/blob/master/src/Providers/Trustpilot/README.md)
+ * [ReviewsIO](https://github.com/Pod-Point/reviews-php/blob/master/src/Providers/ReviewsIo/README.md)
 
 ## Semantic versioning
 Reviews PHP follows [semantic versioning](https://semver.org/) specifications.

--- a/src/ActionsInterface.php
+++ b/src/ActionsInterface.php
@@ -32,5 +32,5 @@ interface ActionsInterface
      *
      * @return mixed
      */
-    public function findReview(string $reviewId);
+    public function findReview(array $options);
 }

--- a/src/Providers/ReviewsIo/MerchantActions.php
+++ b/src/Providers/ReviewsIo/MerchantActions.php
@@ -77,12 +77,12 @@ class MerchantActions implements ActionsInterface
     /**
      * Find review by id.
      *
-     * @param string $reviewId
+     * @param array $options
      *
      * @return array|mixed
      * @throws ValidationException
      */
-    public function findReview(string $reviewId)
+    public function findReview(array $options)
     {
         $options['store'] = $this->config['store'];
 

--- a/src/Providers/ReviewsIo/MerchantActions.php
+++ b/src/Providers/ReviewsIo/MerchantActions.php
@@ -82,12 +82,9 @@ class MerchantActions implements ActionsInterface
      * @return array|mixed
      * @throws ValidationException
      */
-    public function findReview(string $reviewId)
+    public function findReview(array $options = [])
     {
-        $options = [
-            'reviewId' => $reviewId,
-            'store' => $this->config['store'],
-        ];
+        $options['store'] = $this->config['store'];
 
         $request = new FindReviewRequest($this->apiClient, $options);
 

--- a/src/Providers/ReviewsIo/MerchantActions.php
+++ b/src/Providers/ReviewsIo/MerchantActions.php
@@ -77,7 +77,7 @@ class MerchantActions implements ActionsInterface
     /**
      * Find review by id.
      *
-     * @param string $reviewId
+     * @param array $options
      *
      * @return array|mixed
      * @throws ValidationException

--- a/src/Providers/ReviewsIo/MerchantActions.php
+++ b/src/Providers/ReviewsIo/MerchantActions.php
@@ -77,12 +77,12 @@ class MerchantActions implements ActionsInterface
     /**
      * Find review by id.
      *
-     * @param array $options
+     * @param string $reviewId
      *
      * @return array|mixed
      * @throws ValidationException
      */
-    public function findReview(array $options = [])
+    public function findReview(string $reviewId)
     {
         $options['store'] = $this->config['store'];
 

--- a/src/Providers/ReviewsIo/ProductActions.php
+++ b/src/Providers/ReviewsIo/ProductActions.php
@@ -44,7 +44,7 @@ class ProductActions implements ActionsInterface
         //
     }
 
-    public function findReview(string $reviewId)
+    public function findReview(array $options)
     {
         //
     }

--- a/src/Providers/ReviewsIo/README.md
+++ b/src/Providers/ReviewsIo/README.md
@@ -5,7 +5,7 @@
 
 #### Create a ReviewsIO client
 
-The ``\PodPoint\Reviews\Reviews`` class requires, configuration array to be passed in the constructor.   
+The ``\PodPoint\Reviews\Reviews`` class requires, configuration array to be passed in the constructor.
 
 Example config:
 ```php
@@ -16,7 +16,7 @@ $config = [
     ],
 ];
 ```
-  
+
 Any PHP Application
 ```
 $reviews = new \PodPoint\Reviews\Reviews($config);
@@ -45,7 +45,7 @@ $reviewsIo->merchant()->invite([
 
 ```
 See all the supported parameters
-[Api Docs](https://api.reviews.io/documentation/#api-Queue_Email_Invitations-Queue_Merchant_Review_Invite) 
+[Api Docs](https://api.reviews.io/documentation/#api-Queue_Email_Invitations-Queue_Merchant_Review_Invite)
 
 #### Get service reviews
 
@@ -60,7 +60,17 @@ See all supported query parameters and responses:
 
 #### Find service review
 ```php
-$reviewsIo->merchant()->findReview($reviewId);
+$options = [
+    'review_id' => <review_id>,
+];
+
+// or
+
+$options = [
+    'order_number' => <order_number>,
+];
+
+$reviewsIo->merchant()->findReview($options);
 ```
 See response example:
 [Api docs](https://api.reviews.io/documentation/#api-Merchant_Reviews-Get_Latest_Merchant_Reviews)

--- a/src/Providers/ReviewsIo/Request/Merchant/FindReviewRequest.php
+++ b/src/Providers/ReviewsIo/Request/Merchant/FindReviewRequest.php
@@ -17,10 +17,19 @@ class FindReviewRequest extends BaseRequestWrapper
      */
     public function getRequest(): Request
     {
-        $query = http_build_query([
+        $options = [
             'store' => $this->getOption('store'),
-            'review_id' => $this->getOption('reviewId'),
-        ]);
+        ];
+
+        if ($this->getOption('reviewId'])) {
+            $options['review_id'] = $this->getOption('reviewId');
+        }
+
+        if ($this->getOption('orderNumber'])) {
+            $options['order_number'] = $this->getOption('orderNumber');
+        }
+
+        $query = http_build_query($options);
 
         return new Request('GET', '/merchant/reviews?' . $query);
     }

--- a/src/Providers/ReviewsIo/Request/Merchant/FindReviewRequest.php
+++ b/src/Providers/ReviewsIo/Request/Merchant/FindReviewRequest.php
@@ -21,11 +21,11 @@ class FindReviewRequest extends BaseRequestWrapper
             'store' => $this->getOption('store'),
         ];
 
-        if ($this->getOption('review_id'])) {
+        if ($this->getOption('review_id')) {
             $options['review_id'] = $this->getOption('review_id');
         }
 
-        if ($this->getOption('order_number'])) {
+        if ($this->getOption('order_number')) {
             $options['order_number'] = $this->getOption('order_number');
         }
 

--- a/src/Providers/ReviewsIo/Request/Merchant/FindReviewRequest.php
+++ b/src/Providers/ReviewsIo/Request/Merchant/FindReviewRequest.php
@@ -21,12 +21,12 @@ class FindReviewRequest extends BaseRequestWrapper
             'store' => $this->getOption('store'),
         ];
 
-        if ($this->getOption('reviewId'])) {
-            $options['review_id'] = $this->getOption('reviewId');
+        if ($this->getOption('review_id'])) {
+            $options['review_id'] = $this->getOption('review_id');
         }
 
-        if ($this->getOption('orderNumber'])) {
-            $options['order_number'] = $this->getOption('orderNumber');
+        if ($this->getOption('order_number'])) {
+            $options['order_number'] = $this->getOption('order_number');
         }
 
         $query = http_build_query($options);

--- a/src/Providers/Trustpilot/MerchantActions.php
+++ b/src/Providers/Trustpilot/MerchantActions.php
@@ -80,17 +80,13 @@ class MerchantActions implements ActionsInterface
     /**
      * Find reviews by id.
      *
-     * @param string $reviewId
+     * @param array $options
      *
      * @return mixed
      * @throws ValidationException
      */
     public function findReview(array $options)
     {
-        $options = [
-            'reviewId' => $reviewId,
-        ];
-
         $request = new FindReviewRequest($this->apiClient, $options);
 
         return $request->send();

--- a/src/Providers/Trustpilot/MerchantActions.php
+++ b/src/Providers/Trustpilot/MerchantActions.php
@@ -85,7 +85,7 @@ class MerchantActions implements ActionsInterface
      * @return mixed
      * @throws ValidationException
      */
-    public function findReview(string $reviewId)
+    public function findReview(array $options)
     {
         $options = [
             'reviewId' => $reviewId,

--- a/src/Providers/Trustpilot/ProductActions.php
+++ b/src/Providers/Trustpilot/ProductActions.php
@@ -65,7 +65,7 @@ class ProductActions implements ActionsInterface
      *
      * @return mixed
      */
-    public function findReview(string $reviewId)
+    public function findReview(array $options)
     {
         //
     }

--- a/src/Providers/Trustpilot/README.md
+++ b/src/Providers/Trustpilot/README.md
@@ -5,7 +5,7 @@
 
 #### Create a trustpilot client
 
-The ``\PodPoint\Reviews\Reviews`` class requires, configuration array to be passed in the constructor.   
+The ``\PodPoint\Reviews\Reviews`` class requires, configuration array to be passed in the constructor.
 
 Example config:
 ```php
@@ -72,7 +72,7 @@ See all supported query parameters and responses:
 
 #### Find service review
 ```php
-$trustpilot->merchant()->findReview($reviewId);
+$trustpilot->merchant()->findReview($options);
 ```
 See response example:
 [Api docs](https://documentation-apidocumentation.trustpilot.com/service-reviews-api#get-private-review)

--- a/tests/Providers/Reviewsio/MerchantActionsTest.php
+++ b/tests/Providers/Reviewsio/MerchantActionsTest.php
@@ -86,7 +86,9 @@ class MerchantActionsTest extends TestCase
      */
     public function testFindReview()
     {
-        $reviewId = 'review-id-123';
+        $options = [
+            'review_id' => 'review-id-123',
+        ];
 
         $response = $this->getMockedResponse('{"data": [], "message": "successful"}');
         $apiClient = $this->getMockedApiClient();
@@ -96,7 +98,7 @@ class MerchantActionsTest extends TestCase
             'store' => 'store-number-123'
         ]);
 
-        $findReviewResponse = $action->findReview($reviewId);
+        $findReviewResponse = $action->findReview($options);
 
         $expectedResult = [
             'data' => [],

--- a/tests/Providers/Reviewsio/Request/Merchant/FindReviewRequestTest.php
+++ b/tests/Providers/Reviewsio/Request/Merchant/FindReviewRequestTest.php
@@ -53,7 +53,7 @@ class FindReviewRequestTest extends TestCase
         $mockedApiClient = $this->getMockedApiClient();
         $serviceReviewRequest = new FindReviewRequest($mockedApiClient, [
             'store' => 'store-id-321',
-            'reviewId' => 'review-id-123',
+            'review_id' => 'review-id-123',
         ]);
 
         $request = $serviceReviewRequest->getRequest();

--- a/tests/Providers/Trustpilot/MerchantActionsTest.php
+++ b/tests/Providers/Trustpilot/MerchantActionsTest.php
@@ -88,7 +88,9 @@ class MerchantActionsTest extends TestCase
      */
     public function testFindReview()
     {
-        $reviewId = 'review-id-123';
+        $options = [
+            'review_id' => 'review-id-123',
+        ];
 
         $response = $this->getMockedResponse('{"data": [], "message": "successful"}');
         $apiClient = $this->getMockedApiClient();
@@ -100,7 +102,7 @@ class MerchantActionsTest extends TestCase
             'invite_reply_to_email' => 'no-reply@example.com',
         ]);
 
-        $findReviewResponse = $action->findReview($reviewId);
+        $findReviewResponse = $action->findReview($options);
 
         $expectedResult = [
             "data" => [],

--- a/tests/Providers/Trustpilot/MerchantActionsTest.php
+++ b/tests/Providers/Trustpilot/MerchantActionsTest.php
@@ -73,8 +73,8 @@ class MerchantActionsTest extends TestCase
         $getReviewsResponse = $action->getReviews($options);
 
         $expectedResult = [
-            "data" => [],
-            "message" => "successful",
+            'data' => [],
+            'message' => 'successful',
         ];
 
         $this->assertEquals($expectedResult, $getReviewsResponse);
@@ -89,7 +89,7 @@ class MerchantActionsTest extends TestCase
     public function testFindReview()
     {
         $options = [
-            'review_id' => 'review-id-123',
+            'reviewId' => 'review-id-123',
         ];
 
         $response = $this->getMockedResponse('{"data": [], "message": "successful"}');
@@ -105,8 +105,8 @@ class MerchantActionsTest extends TestCase
         $findReviewResponse = $action->findReview($options);
 
         $expectedResult = [
-            "data" => [],
-            "message" => "successful",
+            'data' => [],
+            'message' => 'successful',
         ];
 
         $this->assertEquals($expectedResult, $findReviewResponse);


### PR DESCRIPTION
- Change accepted parameter of findReview function across package to accept options.
- This allows us to find reviews with different options that behave differently between Trustpilot and ReviewsIO api without having to create a new function for each specific case that we might need.
- The need for this was discovered because OT needs to search reviews via $installation->uuid, not its reviewId