### PR TITLE
[SWP-1932] Hotfix Changes. Introduce findReviewByOrderNumber().

### DIFF
--- a/src/ActionsInterface.php
+++ b/src/ActionsInterface.php
@@ -26,11 +26,20 @@ interface ActionsInterface
     public function getReviews(array $options = []);
 
     /**
-     * Find reviews by id.
+     * Find reviews by review id.
      *
      * @param string $reviewId
      *
      * @return mixed
      */
     public function findReview(string $reviewId);
+
+    /**
+     * Find reviews by order number.
+     *
+     * @param string $orderNumber
+     *
+     * @return mixed
+     */
+    public function findReviewByOrderNumber(string $orderNumber);
 }

--- a/src/Providers/ReviewsIo/MerchantActions.php
+++ b/src/Providers/ReviewsIo/MerchantActions.php
@@ -93,4 +93,24 @@ class MerchantActions implements ActionsInterface
 
         return $request->send();
     }
+
+    /**
+     * Find review by order_number.
+     *
+     * @param string $orderNumber
+     *
+     * @return array|mixed
+     * @throws ValidationException
+     */
+    public function findReviewByOrderNumber(string $orderNumber)
+    {
+        $options = [
+            'orderNumber' => $orderNumber,
+            'store' => $this->config['store'],
+        ];
+
+        $request = new FindReviewRequest($this->apiClient, $options);
+
+        return $request->send();
+    }
 }

--- a/src/Providers/ReviewsIo/MerchantActions.php
+++ b/src/Providers/ReviewsIo/MerchantActions.php
@@ -95,7 +95,7 @@ class MerchantActions implements ActionsInterface
     }
 
     /**
-     * Find review by order_number.
+     * Find review by order number.
      *
      * @param string $orderNumber
      *

--- a/src/Providers/ReviewsIo/ProductActions.php
+++ b/src/Providers/ReviewsIo/ProductActions.php
@@ -48,4 +48,9 @@ class ProductActions implements ActionsInterface
     {
         //
     }
+
+    public function findReviewByOrderNumber(string $orderNumber)
+    {
+        //
+    }
 }

--- a/src/Providers/ReviewsIo/Request/Merchant/FindReviewByOrderNumberRequest.php
+++ b/src/Providers/ReviewsIo/Request/Merchant/FindReviewByOrderNumberRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace PodPoint\Reviews\Providers\ReviewsIo\Request\Merchant;
+
+use GuzzleHttp\Psr7\Request;
+use PodPoint\Reviews\Request\BaseRequestWrapper;
+
+/**
+ * Class FindReviewByOrderNumberRequest.
+ */
+class FindReviewByOrderNumberRequest extends BaseRequestWrapper
+{
+    /**
+     * Builds the request.
+     *
+     * @return Request
+     */
+    public function getRequest(): Request
+    {
+        $query = http_build_query([
+            'store' => $this->getOption('store'),
+            'order_number' => $this->getOption('orderNumber'),
+        ]);
+
+        return new Request('GET', '/merchant/reviews?' . $query);
+    }
+
+    /**
+     * List of required fields.
+     *
+     * @return array
+     */
+    public function requiredFields(): array
+    {
+        return ['orderNumber'];
+    }
+
+    /**
+     * Sends the request and parses response into array.
+     *
+     * @return array|mixed
+     */
+    public function send()
+    {
+        $response = $this->httpClient->sendRequest(
+            $this->getRequest(),
+            true
+        );
+
+        return $this->httpClient->getResponseJson($response);
+    }
+}

--- a/src/Providers/ReviewsIo/Request/Merchant/FindReviewRequest.php
+++ b/src/Providers/ReviewsIo/Request/Merchant/FindReviewRequest.php
@@ -32,7 +32,7 @@ class FindReviewRequest extends BaseRequestWrapper
      */
     public function requiredFields(): array
     {
-        return [];
+        return ['reviewId'];
     }
 
     /**

--- a/src/Providers/Trustpilot/MerchantActions.php
+++ b/src/Providers/Trustpilot/MerchantActions.php
@@ -95,4 +95,16 @@ class MerchantActions implements ActionsInterface
 
         return $request->send();
     }
+
+    /**
+     * Find reviews by order number.
+     *
+     * @param string $orderNumber
+     *
+     * @return mixed
+     */
+    public function findReviewByOrderNumber(string $orderNumber)
+    {
+        //
+    }
 }

--- a/src/Providers/Trustpilot/ProductActions.php
+++ b/src/Providers/Trustpilot/ProductActions.php
@@ -69,4 +69,16 @@ class ProductActions implements ActionsInterface
     {
         //
     }
+
+    /**
+     * Find reviews by order number.
+     *
+     * @param string $orderNumber
+     *
+     * @return mixed
+     */
+    public function findReviewByOrderNumber(string $orderNumber)
+    {
+        //
+    }
 }

--- a/tests/Providers/Reviewsio/Request/Merchant/FindReviewByOrderNumberRequestTest.php
+++ b/tests/Providers/Reviewsio/Request/Merchant/FindReviewByOrderNumberRequestTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace PodPoint\Reviews\Tests\Providers\ReviewsIo\Request\Merchant;
+
+use PodPoint\Reviews\Providers\ReviewsIo\Request\Merchant\FindReviewByOrderNumberRequest;
+use PodPoint\Reviews\Tests\TestCase;
+
+class FindReviewByOrderNumberRequestTest extends TestCase
+{
+    /**
+     * Test construct to make sure properties are set.
+     *
+     * @throws \PodPoint\Reviews\Exceptions\ValidationException
+     */
+    public function testConstruct()
+    {
+        $mockedApiClient = $this->getMockedApiClient();
+        $request = new FindReviewByOrderNumberRequest($mockedApiClient, [
+            'store' => 'store-id-321',
+            'orderNumber' => 'order-id-123'
+        ]);
+
+        $this->assertEquals($mockedApiClient, $request->getHttpClient());
+        $this->assertEquals([
+            'store' => 'store-id-321',
+            'orderNumber' => 'order-id-123',
+        ], $request->getOptions());
+    }
+
+    /**
+     * Making sure the required fields returns the right required fields.
+     *
+     * @throws \PodPoint\Reviews\Exceptions\ValidationException
+     */
+    public function testRequiredFields()
+    {
+        $mockedApiClient = $this->getMockedApiClient();
+        $request = new FindReviewByOrderNumberRequest($mockedApiClient, [
+            'store' => 'store-id-321',
+            'orderNumber' => 'order-id-123',
+        ]);
+
+        $this->assertEquals(['orderNumber'], $request->requiredFields());
+    }
+
+    /**
+     * Making sure the Request instance is build as expected.
+     *
+     * @throws \PodPoint\Reviews\Exceptions\ValidationException
+     */
+    public function testGetRequest()
+    {
+        $mockedApiClient = $this->getMockedApiClient();
+        $serviceReviewRequest = new FindReviewByOrderNumberRequest($mockedApiClient, [
+            'store' => 'store-id-321',
+            'orderNumber' => 'order-id-123',
+        ]);
+
+        $request = $serviceReviewRequest->getRequest();
+
+        $this->assertInstanceOf(\Psr\Http\Message\RequestInterface::class, $request);
+
+        $this->assertEquals('/merchant/reviews', $request->getUri()->getPath());
+        $this->assertEquals('store=store-id-321&order_number=order-id-123', $request->getUri()->getQuery());
+    }
+
+    /**
+     * Send should return an array by converting the json response.
+     *
+     * @throws \PodPoint\Reviews\Exceptions\ValidationException
+     */
+    public function testSend()
+    {
+        $response = $this->getMockedResponse('{"status": "OK", "message": "successful"}');
+        $mockedApiClient = $this->getMockedApiClient();
+        $mockedApiClient->shouldReceive('sendRequest')->withAnyArgs()->andReturn($response);
+
+        $request = new FindReviewByOrderNumberRequest($mockedApiClient, [
+            'store' => 'store-id-321',
+            'orderNumber' => 'order-id-123',
+        ]);
+
+        $this->assertEquals([
+            'status' => 'OK',
+            'message' => 'successful',
+        ], $request->send());
+    }
+}

--- a/tests/Providers/Reviewsio/Request/Merchant/FindReviewRequestTest.php
+++ b/tests/Providers/Reviewsio/Request/Merchant/FindReviewRequestTest.php
@@ -40,7 +40,7 @@ class FindReviewRequestTest extends TestCase
             'reviewId' => 'review-id-123',
         ]);
 
-        $this->assertEquals([], $request->requiredFields());
+        $this->assertEquals(['reviewId'], $request->requiredFields());
     }
 
     /**


### PR DESCRIPTION
• Add a new function that allows to search reviews by order number.
• This allows us to find reviews with different options that behave differently between Trustpilot and ReviewsIO api.
• Needed because OT needs to search reviews via $installation->uuid, not its reviewId.